### PR TITLE
bug: multi return, accessed in single val context

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -28,6 +28,6 @@ func NewCookie(name, value string, options *Options) *http.Cookie {
 }
 
 func generateUUID() string {
-	v1 := uuid.NewV1()
+	v1, _ := uuid.NewV1()
 	return hex.EncodeToString(v1.Bytes())
 }


### PR DESCRIPTION
github.com/satori/go.uuid `uuid.NewV1` returns the uuid and an error.
This ignores the error, but fixes issue of accessing in single value
context.