### PR TITLE
update

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -28,6 +28,6 @@ func NewCookie(name, value string, options *Options) *http.Cookie {
 }
 
 func generateUUID() string {
-	v1 := uuid.NewV1()
+	v1 := uuid.Must(uuid.NewV1())
 	return hex.EncodeToString(v1.Bytes())
 }


### PR DESCRIPTION
github.com/plimble/sessions/utils.go:31:18: multiple-value uuid.NewV1()
in single-value context
Because `commit 0ef6afb2f6cdd6cdaeee3885a95099c63f18fc8c` in go.uuid